### PR TITLE
Correct payload for method

### DIFF
--- a/help/library/get-set/resetstate.md
+++ b/help/library/get-set/resetstate.md
@@ -36,12 +36,14 @@ If you've set up the ID service with a [non-standard implementation](../../imple
 ```js
 //Instantiate server state variable 
 var serverState = { 
-     "Insert Experience Cloud organization ID here": { 
-          //Specify the SDID or other ID 
-          supplementalDataIDCurrent: "1234", 
-          supplementalDataIDCurrentConsumed: { 
-               "payload:top-center": false 
-          } 
+     "Insert Experience Cloud organization ID here": {
+          sdid: {
+               //Specify the SDID or other ID 
+               supplementalDataIDCurrent: "1234", 
+               supplementalDataIDCurrentConsumed: { 
+                    "payload:top-center": false 
+               }
+          }
      } 
 }; 
  


### PR DESCRIPTION
resetState does not work as documented here. It is missing a required child attribute called "sdid" which then contains the supplementalDataIDCurrent, etc. attributes. The current example will just reset the state completely.